### PR TITLE
Make interpreter installable via shard

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ install IC at `/usr/local/`
 sudo make install
 ```
 
+### As a Shard
+
+Add this to your `shard.yml` file:
+
+```yaml
+development_dependencies:
+  ic:
+    github: I3oris/ic
+```
+
+And run `shards install`
+
 ## Usage:
 
 ### Interactive mode:

--- a/shard.yml
+++ b/shard.yml
@@ -12,6 +12,9 @@ crystal: 1.1.1
 
 license: MIT
 
+scripts:
+  postinstall: make postinstall
+
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba


### PR DESCRIPTION
I like the pattern that ameba has, where adding it as a shard creates the binary under the `bin` directory. Results in multiple `ameba` instances on my machine, but they're all scoped to their individual projects. I added a post install script to ic to create the `ic` binary under `bin` as well, verified with one of my other projects that it runs with basic commands.

Thanks for making `ic`, it's awesome! I wish the compiler already had the interpreter enabled, but at least adding a shard makes it easy enough to get access to it :)