### PR TITLE
Load crystal stdlib in background during REPL startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ CRYSTAL_CONFIG_PATH ?= '$$ORIGIN/../share/crystal-ic/src'
 CRYSTAL_LIB_CONFIG_PATH ?= '$$ORIGIN/../lib/ic/share/crystal-ic/src'
 
 COMPILER ?= crystal
-FLAGS ?= --progress
-RELEASE_FLAGS ?= --progress --release
+FLAGS ?= -Dpreview_mt --progress
+RELEASE_FLAGS ?= -Dpreview_mt --progress --release
 
 ENV ?= CRYSTAL_CONFIG_PATH=$(CRYSTAL_CONFIG_PATH) CRYSTAL_PATH=$(CRYSTAL_PATH)
 ENV_LIB ?= CRYSTAL_CONFIG_PATH=$(CRYSTAL_LIB_CONFIG_PATH) CRYSTAL_PATH=$(CRYSTAL_PATH)

--- a/shard.yml
+++ b/shard.yml
@@ -18,4 +18,3 @@ scripts:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.0

--- a/src/repl.cr
+++ b/src/repl.cr
@@ -7,7 +7,9 @@ class Crystal::Repl
   def run
     color = @program.color?
 
-    load_prelude
+    spawn do
+      load_prelude
+    end
 
     repl_interface = IC::ReplInterface::ReplInterface.new
     repl_interface.color = color


### PR DESCRIPTION
Gist is that the stdlib could be more efficiently loaded in the background while the user is entering in their first line :) This cuts REPL startup time from ~1/2 second to instantaneously, and everything loads correctly.

I tested adding a `sleep 30` in the spawn below to simulate user input _before_ everything was loaded, and ended up seeing a much shorter list in the tab complete of what I could do (as expected). Waiting out the 30 seconds had everything load in the same session and tab complete "fixed" itself.