### PR TITLE
Remove interpreter needing to be relative to "share" directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CRYSTAL_ROOT ?= $(shell pwd)/share/crystal-ic/src
 CRYSTAL_PATH ?= lib:$(CRYSTAL_ROOT):$(CRYSTAL_ROOT)/../lib
-CRYSTAL_CONFIG_PATH ?= '$$ORIGIN/../share/crystal-ic/src'
-CRYSTAL_LIB_CONFIG_PATH ?= '$$ORIGIN/../lib/ic/share/crystal-ic/src'
+CRYSTAL_CONFIG_PATH ?= '/crystal-ic/src'
+CRYSTAL_LIB_CONFIG_PATH ?= '/crystal-ic/src'
 
 COMPILER ?= crystal
 FLAGS ?= -Dpreview_mt --progress

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
 CRYSTAL_ROOT ?= $(shell pwd)/share/crystal-ic/src
 CRYSTAL_PATH ?= lib:$(CRYSTAL_ROOT):$(CRYSTAL_ROOT)/../lib
 CRYSTAL_CONFIG_PATH ?= '/crystal-ic/src'
-CRYSTAL_LIB_CONFIG_PATH ?= '/crystal-ic/src'
 
 COMPILER ?= crystal
 FLAGS ?= -Dpreview_mt --progress
 RELEASE_FLAGS ?= -Dpreview_mt --progress --release
 
 ENV ?= CRYSTAL_CONFIG_PATH=$(CRYSTAL_CONFIG_PATH) CRYSTAL_PATH=$(CRYSTAL_PATH)
-ENV_LIB ?= CRYSTAL_CONFIG_PATH=$(CRYSTAL_LIB_CONFIG_PATH) CRYSTAL_PATH=$(CRYSTAL_PATH)
 SOURCES := $(shell find src -name '*.cr')
 O := bin/ic
 
@@ -65,12 +63,7 @@ clean:
 	rm -f $(LLVM_EXT_OBJ)
 	rm -f $(O)
 
-.PHONY: lib_build
-lib_build: clean $(LLVM_EXT_OBJ)
-	mkdir -p bin
-	$(ENV_LIB) $(COMPILER) build $(FLAGS) src/ic.cr -o $(O)
-
 .PHONY: postinstall
-postinstall: lib_build
+postinstall: clean all
 	mkdir -p ../../bin
 	cp $(O) ../../bin/

--- a/shard.yml
+++ b/shard.yml
@@ -11,6 +11,10 @@ license: MIT
 scripts:
   postinstall: make postinstall
 
+dependencies:
+  baked_file_system:
+    github: schovi/baked_file_system
+
 development_dependencies:
   ameba:
     version: 1.4.3

--- a/src/ext/crystal_path.cr
+++ b/src/ext/crystal_path.cr
@@ -39,7 +39,7 @@ module Crystal
               files << path if path.starts_with?(relative_dir) && (path =~ /#{relative_dir}[^\/]+.cr/)
             end
           end
-          return files
+          return files.sort!
         end
 
         return nil

--- a/src/ext/crystal_path.cr
+++ b/src/ext/crystal_path.cr
@@ -1,0 +1,54 @@
+module Crystal
+  struct CrystalPath
+    private def add_target_path(codegen_target)
+      target = "#{codegen_target.architecture}-#{codegen_target.os_name}"
+
+      @entries.each do |path|
+        path = File.join(path, "lib_c", target)
+        if Dir.exists?(path) || FileStorage.files.map(&.path).any?(&.starts_with?(path))
+          @entries << path unless @entries.includes?(path)
+          return
+        end
+      end
+    end
+
+    private def find_in_path_relative_to_dir(filename, relative_to)
+      return unless relative_to.is_a?(String)
+
+      # Check if it's a wildcard.
+      if filename.ends_with?("/*") || (recursive = filename.ends_with?("/**"))
+        filename_dir_index = filename.rindex!('/')
+        filename_dir = filename[0..filename_dir_index]
+        relative_dir = "#{relative_to}/#{filename_dir}".gsub("/./", "/")
+        relative_dir = "/#{relative_dir}" unless relative_dir.starts_with?("/")
+
+        if File.exists?(relative_dir)
+          files = [] of String
+          gather_dir_files(relative_dir, files, recursive)
+          return files
+        end
+
+        if FileStorage.files.map(&.path).any?(&.starts_with?(relative_dir))
+          files = [] of String
+          FileStorage.files.map(&.path).each do |path|
+            if filename.ends_with?("/**")
+              files << path if path.starts_with?(relative_dir)
+            else
+              files << path if path.starts_with?(relative_dir) && (path =~ /#{relative_dir}[^\/]+.cr/)
+            end
+          end
+          return files
+        end
+
+        return nil
+      end
+
+      each_file_expansion(filename, relative_to) do |path|
+        absolute_path = File.expand_path(path, dir: @current_dir)
+        return absolute_path if File.file?(absolute_path) || FileStorage.get?(absolute_path)
+      end
+
+      nil
+    end
+  end
+end

--- a/src/ext/crystal_path.cr
+++ b/src/ext/crystal_path.cr
@@ -1,4 +1,6 @@
 module Crystal
+  # All methods overwritten here directly copied from share/crystal-ic/src/compiler/crystal/crystal_path.cr,
+  # and updated for checking FileStorage
   struct CrystalPath
     private def add_target_path(codegen_target)
       target = "#{codegen_target.architecture}-#{codegen_target.os_name}"

--- a/src/ext/semantic_visitor.cr
+++ b/src/ext/semantic_visitor.cr
@@ -1,4 +1,6 @@
 abstract class Crystal::SemanticVisitor < Crystal::Visitor
+  # This is a copy / paste of share/crystal-ic/src/compiler/crystal/semantic/semantic_visitor.cr
+  # with the only update being to support reading files from FileStorage
   private def require_file(node : Require, filename : String)
     parser = @program.new_parser(
       File.exists?(filename) ? File.read(filename) : FileStorage.get(filename).gets_to_end

--- a/src/ext/semantic_visitor.cr
+++ b/src/ext/semantic_visitor.cr
@@ -1,0 +1,22 @@
+abstract class Crystal::SemanticVisitor < Crystal::Visitor
+  private def require_file(node : Require, filename : String)
+    parser = @program.new_parser(
+      File.exists?(filename) ? File.read(filename) : FileStorage.get(filename).gets_to_end
+    )
+    parser.filename = filename
+    parser.wants_doc = @program.wants_doc?
+    begin
+      parsed_nodes = parser.parse
+      parsed_nodes = @program.normalize(parsed_nodes, inside_exp: inside_exp?)
+      # We must type the node immediately, in case a file requires another
+      # *before* one of the files in `filenames`
+      parsed_nodes.accept self
+    rescue ex : CodeError
+      node.raise "while requiring \"#{node.string}\"", ex
+    rescue ex
+      raise Error.new "while requiring \"#{node.string}\"", ex
+    end
+
+    FileNode.new(parsed_nodes, filename)
+  end
+end

--- a/src/ic.cr
+++ b/src/ic.cr
@@ -1,5 +1,12 @@
 require "./repl"
 require "option_parser"
+require "baked_file_system"
+
+class FileStorage
+  extend BakedFileSystem
+
+  bake_folder "./../share/"
+end
 
 module IC
   VERSION = "0.7.0"

--- a/src/ic.cr
+++ b/src/ic.cr
@@ -1,12 +1,5 @@
 require "./repl"
 require "option_parser"
-require "baked_file_system"
-
-class FileStorage
-  extend BakedFileSystem
-
-  bake_folder "./../share/"
-end
 
 module IC
   VERSION = "0.7.0"

--- a/src/repl.cr
+++ b/src/repl.cr
@@ -2,6 +2,7 @@ require "compiler/crystal/interpreter"
 require "./pry"
 require "./crystal_errors"
 require "./repl_readers"
+require "./ext/*"
 
 class Crystal::Repl
   getter? prelude_complete = false
@@ -104,6 +105,11 @@ class Crystal::Repl
 
   def bind_keyboard_interrupt
     @interpreter.bind_keyboard_interrupt
+  end
+
+  private def parse_file(filename)
+    file_contents = File.exists?(filename) ? File.read(filename) : FileStorage.get(filename).gets_to_end
+    parse_code file_contents, filename
   end
 end
 

--- a/src/repl.cr
+++ b/src/repl.cr
@@ -3,6 +3,13 @@ require "./pry"
 require "./crystal_errors"
 require "./repl_readers"
 require "./ext/*"
+require "baked_file_system"
+
+class FileStorage
+  extend BakedFileSystem
+
+  bake_folder "./../share/"
+end
 
 class Crystal::Repl
   getter? prelude_complete = false


### PR DESCRIPTION
This PR uses the [baked_file_system](https://github.com/schovi/baked_file_system/tree/master) shard to add the entire `share` directory to the built binary, and then adds various monkey patches to allow the `prelude` to read those files from the virtual filesystem if they don't exist in their expected location.

This allows the constructed `ic` binary to not need a `lib` specific setup / build, and can potentially be run on machines without crystal installed at all (but still require the linked dynamic libraries).

Let me know if you find this useful, or don't wish to make such edits or updates to the interpreter directly :)