### PR TITLE
Update Makefile for Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ O := bin/ic
 # LLVM:
 LLVM_EXT_DIR := $(CRYSTAL_ROOT)/llvm/ext
 LLVM_EXT_OBJ := $(LLVM_EXT_DIR)/llvm_ext.o
-LLVM_CONFIG ?= $(shell $(CRYSTAL_ROOT)/llvm/ext/find-llvm-config)
+LLVM_CONFIG ?= $(shell $(CRYSTAL_ROOT)/llvm/ext/find-llvm-config.sh)
 
 # INSTALL:
 DESTDIR ?= /usr/local
@@ -28,6 +28,9 @@ all: $(O)
 $(O): $(LLVM_EXT_OBJ) $(SOURCES)
 	mkdir -p bin
 	$(ENV) $(COMPILER) build $(FLAGS) src/ic.cr -o $(O)
+
+$(LLVM_EXT_OBJ): $(LLVM_EXT_DIR)/llvm_ext.cc
+	$(CXX) -c $(CXXFLAGS) -o $@ $< $(if $(LLVM_CONFIG),$(shell $(LLVM_CONFIG) --cxxflags))
 
 .PHONY: release
 release:


### PR DESCRIPTION
I think I found a couple issues in the Makefile (originally on a Mac, hence the title, but I think these are generic).

The first is that line 19 is referring to `$(CRYSTAL_ROOT)/llvm/ext/find-llvm-config` instead of `$(CRYSTAL_ROOT)/llvm/ext/find-llvm-config.sh`.

The second is that cxxflags aren't appended.

Prior to these changes I was getting:
```
>make                                                                                                                      [18:41]
c++  -I/opt/homebrew/opt/openjdk/include  -c -o /Users/dberger/Dev/ic/share/crystal-ic/src/llvm/ext/llvm_ext.o /Users/dberger/Dev/ic/share/crystal-ic/src/llvm/ext/llvm_ext.cc
/Users/dberger/Dev/ic/share/crystal-ic/src/llvm/ext/llvm_ext.cc:1:10: fatal error: 'llvm/Config/llvm-config.h' file not found
    1 | #include <llvm/Config/llvm-config.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make: *** [/Users/dberger/Dev/ic/share/crystal-ic/src/llvm/ext/llvm_ext.o] Error 1
```